### PR TITLE
Fixed grammatical error in queries.mdx

### DIFF
--- a/docs/rtk-query/usage/queries.mdx
+++ b/docs/rtk-query/usage/queries.mdx
@@ -225,7 +225,7 @@ function App() {
 }
 ```
 
-While `data` is expected to used in the majority of situations, `currentData` is also provided,
+While `data` is expected to be used in the majority of situations, `currentData` is also provided,
 which allows for a further level of granularity. For example, if you wanted to show data in the UI
 as translucent to represent a re-fetching state, you can use `data` in combination with `isFetching`
 to achieve this. However, if you also wish to _only_ show data corresponding to the current arg,


### PR DESCRIPTION
Refactored sentence to make more sense:
`While data is expected to used in the majority...` to `While data is expected to BE used in the majority...`